### PR TITLE
Perl/Raku Week045 reviews, allow HTML in .md

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -81,6 +81,10 @@ publishDir = "docs"
         [[params.banner.flipText]]
             title   = "Mentor"
 
+    # Enable HTML in markup, needed for image control
+    [markup.goldmark.renderer]
+        unsafe  = true
+
     # Homepage About Section
     [params.about]
         enable  = true

--- a/content/blog/p6-review-challenge-045.md
+++ b/content/blog/p6-review-challenge-045.md
@@ -1,0 +1,659 @@
+---
+author: Ryan Thompson
+date: 2020-02-06T00:22:54
+description: "Ryan Thompson › Raku Weekly Review: Challenge - #045"
+tags: ["raku"]
+title: "Ryan Thompson › Raku Weekly Review: Challenge - #045"
+type: post
+---
+
+Welcome to the Raku review for Week 045 of the Weekly Challenge! For a quick overview, go through the [original tasks](/blog/perl-weekly-challenge-045/) and [recap](/blog/recap-challenge-045/) of the weekly challenge.
+
+I'm filling in for Laurent this week with the Raku review.
+
+## Getting in Touch
+
+<a href="mailto:rjt@cpan.org"><img src="http://ry.ca/misc/Email.svg" height="50" width="50"> Email</a> › Email me (Ryan) with any feedback about this review.
+
+<a href="https://github.com/manwar/perlweeklychallenge"><img src="http://ry.ca/misc/Github.svg" height="50" width="50"> GitHub</a> › Submit a pull request for any issues you may find with this page.
+
+<a href="https://twitter.com/perlwchallenge"><img src="http://ry.ca/misc/Twitter.svg" height="50" width="50"> Twitter</a> › Join the discussion on Twitter!
+
+We'd greatly appreciate any feedback you'd like to give.
+
+
+## Table of Contents
+
+ * [Task 1](#task1)
+ * [Task 2](#task2)
+ * [Blogs](#blogs)
+
+
+*** ***
+
+# Task #1 › Square Secret Code {#task1}
+
+***
+
+## Original task description
+
+The square secret code mechanism first removes any space from the original message. Then it lays down the message in a row of 8 columns. The coded message is then obtained by reading down the columns going left to right.
+
+For example, the message is **“The quick brown fox jumps over the lazy dog”.**
+
+Then the message would be laid out as below:
+
+```
+thequick
+brownfox
+jumpsove
+rthelazy
+dog
+```
+**Figure 1** › Partitioned Plaintext
+
+The code message would be as below:
+
+```
+tbjrd hruto eomhg qwpe unsl ifoa covz kxey
+```
+
+***
+
+## My general observations
+
+There were three key ways people approached this task:
+
+### 1. Partitioning and Looping
+
+By first splitting the plaintext into column-width substrings, you end up with **Figure 1** (above). From there, you can simply append the first character of each string to your output, then the second character, and so on.
+
+This method is perhaps the most obvious implementation of the problem description, as it follows the wording quite closely.
+
+### 2. `zip`, `[Z~]` or `roundrobin`
+
+This method builds on the first by taking advantage of these Raku builtins. After partitioning the string into 8-character arrays, those arrays can be simply fed through any of `zip`, `[Z~]` or `roundrobin`, and then `join`ed together.
+
+### 3. `.comb` and Modulo Arithmetic
+
+For this method, you first split the plaintext into a list of chars with `.comb`. Then, you loop over the plaintext array, appending each character into its `$index % $columns` string in an array of `@columns`. Finally, you simply `join` the columns together.
+
+***
+
+If my plain English descriptions don't make complete sense yet, don't worry; there will be plenty of code examples below. 
+
+
+## Arne Sommer
+
+[Arne Sommer's solution](https://github.com/manwar/perlweeklychallenge-club/blob/master/challenge-045/arne-sommer/raku/ch-1.p6) removes spaces (and also removes double quotes) and then splits the input into a character array. Finally, he uses a nested loop to print the solution character by character:
+
+```raku
+unit sub MAIN ($string is copy = "The quick brown fox jumps over the lazy dog", :$verbose);
+$string ~~ tr/" "//;
+say ": { $string.lc }" if $verbose;
+my @a = $string.lc.comb;
+
+for 0 .. 7 -> $word {
+  my $index = $word;
+  loop {
+    @a[$index]:exists
+      ?? print  @a[$index]
+      !! ( print " "; last);
+
+    $index += 8;
+  }
+}
+say "";
+```
+
+Arne's loops allow him to scan over `@a` 8 characters at a time, shifting the starting position from 0 to 7, so he scans each column.
+
+**Blog** › [Square Dumper with Raku](https://raku-musings.com/square-dumper.html)  
+
+## Burkhard Nickels
+
+[Burkhard Nickels' solution](https://github.com/manwar/perlweeklychallenge-club/blob/master/challenge-045/burkhard-nickels/raku/ch-1.p6) uses a C-style `loop` to advance 8 characters at a time:
+
+```raku
+$msg ~~ s:g/\s//;
+$msg = $msg.lc;
+my @l = split("",$msg);
+
+my $coded_msg;
+for (1 .. 8) {
+    loop (my $j = $_; $j <= @l.end; $j += 8) {
+        $coded_msg ~= @l[ $j ];
+    }
+    $coded_msg ~= " ";
+}
+print "Coded   : $coded_msg\n";
+```
+
+**Blog** › [Square Secret Code](https://github.com/manwar/perlweeklychallenge-club/blob/master/challenge-045/burkhard-nickels/perl/ch-1.pod)
+
+## Colin Crain
+
+[Colin Crain's solution](https://github.com/manwar/perlweeklychallenge-club/blob/master/challenge-045/colin-crain/raku/ch-1.p6) is a first example we'll see of a `zip` or `roundrobin` solution:
+
+```raku
+sub MAIN (Str:D $raw = "The quick brown fox jumps over the lazy dog" ) {
+    my $input = $raw.comb.grep( /\w/ ).join( '' ).lc;
+    my @output = roundrobin ($input.comb(8)).map({ .comb });
+    say join ' ', @output.map({ .join });
+}
+```
+
+Colin first strips all non-word characters and converts the input to lowercase.
+
+He then uses `comb(8)` to split the strings into 8-character strings, and `.comb` on each of those to convert them to character arrays. And then it gets interesting:
+
+The [roundrobin](https://docs.perl6.org/routine/roundrobin) routine (which is similar to [zip](https://docs.perl6.org/type/List#routine_zip), except it handles lists of uneven lengths) takes the first character from each list, then the second, then the third, and so on. That's the exact ordering we need.
+
+## Jaldhar H. Vyas
+
+[Jaldhar H. Vyas' solution](https://github.com/manwar/perlweeklychallenge-club/blob/master/challenge-045/jaldhar-h-vyas/raku/ch-1.p6) is another very compact one:
+
+```raku
+multi sub MAIN(*@ARGS) {
+    my $input = @*ARGS.lc.join(q{ }).subst(/\s+/, q{}, :g);
+    $input ~= q{ } x 8 - ($input.chars % 8);
+    ([Z~] $input.comb.rotor(8)).join(q{ }).subst(/' '+/, q{ }, :g).say;
+}
+```
+
+The first line joins the arguments, converting them to lowercase removing spaces. The second line then pads the input string to be a multiple of 8 characters.
+
+The third line first splits `$input` into a character array with `.comb`, and then uses `rotor(8)` for the array the same way Colin used `.comb(8)` for a string. Jaldhar then `.join`s them with spaces, and trims repeated spaces. The result of all of this is then fed through the reduction metaoperator `[Z~]` to do the zip operation.
+
+**Blog** › [Perl Weekly Challenge 045](https://www.braincells.com/perl/2020/02/perl_weekly_challenge_week_45.html)
+
+## Javier Luque
+
+[Javier Luque's solution](https://github.com/manwar/perlweeklychallenge-club/blob/master/challenge-045/javier-luque/raku/ch-1.p6) uses the `.comb` and modulo arithmetic approach to build up `@new_words` character by character:
+
+```raku
+sub MAIN(Str $string) {
+    my @new_words;
+    @new_words[$_] = '' for (0..7);
+
+    my $clean_string = $string;
+    $clean_string ~~ s:g/\s//;
+    my @chars = $clean_string.comb;
+
+    for (0 .. @chars.elems - 1) -> $i {
+        @new_words[$i % 8] =
+            @new_words[$i % 8] ~ @chars[$i];
+    }
+
+    say @new_words.join(' ');
+}
+```
+
+**Blog** › [PERL WEEKLY CHALLENGE – 045 – Perl Weekly Challenge](https://perlchallenges.wordpress.com/2020/01/30/perl-weekly-challenge-045/)
+
+
+## Jan Ole Kraft
+
+[Jan Ole Kraft's solution](https://github.com/manwar/perlweeklychallenge-club/blob/master/challenge-045/jokraft/raku/ch-1.p6) splits the string into characters, and then uses a nested loop with indexing arithmetic to build up the output, character by character:
+
+```raku
+$str = $str.subst(" ","",:g);
+my @arr = $str.split("", :skip-empty);
+my $out = "";
+for (0..7) -> $i {
+  my $c = 0;
+  while $c * 8 + $i < @arr.elems {
+    $out = $out ~ @arr[$i + $c*8];
+    $c++;
+  }
+  $out = $out ~ " ";
+}
+say $out;
+```
+
+## Laurent Rosenfeld
+
+[Laurent Rosenfeld's solution](https://github.com/manwar/perlweeklychallenge-club/blob/master/challenge-045/laurent-rosenfeld/raku/ch-1.p6) chunks the input into 8-character strings, and then loops over each column. Laurent prints each `join`ed segment together, built up from the `$i`th character of each 8-character string via `substr`:
+
+```raku
+my $msg = @*ARGS ?? shift @*ARGS
+    !! "The quick brown fox jumps over the lazy dog";
+$msg ~~ s:g/\s+//;
+my @letters = map { ~ $_}, $msg ~~ m:g/ .**1..8/;
+for 0..7 -> $i {
+    print " ", join "", map { substr  $_, $i, 1 if .chars >= $i}, @letters;
+}
+```
+
+**Blog** › [Perl Weekly Challenge 45: Square Secret Code and Source Dumper](http://blogs.perl.org/users/laurent_r/2020/02/perl-weekly-challenge-45-square-secret-code-and-source-dumper.html)
+
+
+## Luca Ferrari
+
+[Luca Ferrari's solution](https://github.com/manwar/perlweeklychallenge-club/blob/master/challenge-045/luca-ferrari/raku/ch-1.p6) is another that uses `rotor` to chunk the filtered input into `$columns`-character arrays:
+
+```raku
+my @matrix = $message.lc.comb( /\w/ ).rotor: $columns, :partial;
+
+say "Your original message is \n\t$message\n and encoded results:\n";
+@matrix.join( "\n" ).say;
+say "\nthat leads to\n";
+for 0 .. $columns -> $start {
+    ( @matrix[ $_ ][ $start ] // '' ).print for 0 .. @matrix.elems;
+}
+```
+
+Luca's nested loop takes care of the indexing into both arrays to print out the solution in the correct order.
+
+**Blog** › [Perl Weekly Challenge 45: encoded messages and self-source-code-printing](https://fluca1978.github.io/2020/01/29/PerlWeeklyChallenge45.html)
+
+
+## Mark Anderson
+
+[Mark Anderson's solution](https://github.com/manwar/perlweeklychallenge-club/blob/master/challenge-045/mark-anderson/raku/ch-1.p6) uses the `zip` method to elegant effect:
+
+```raku
+my @array.push: [.split({}, :skip-empty)] for $string.comb(8);
+@array[*-1].push: " " for @array[*-1].elems..7;
+@array = [Z] @array;
+$_ = .join.trim-trailing for @array;
+say @array.join: " ";
+```
+
+Once the `@array` has been put through `[Z]`, each of the sub-arrays may contain trailing spaces if the input wasn't a multiple of 8 characters in length, so Mark uses `.trim-trailing` in-place to clean those up, before printing the result.
+
+## Markus Holzer
+
+[Markus Holzer's solution](https://github.com/manwar/perlweeklychallenge-club/blob/master/challenge-045/markus-holzer/raku/ch-1.p6) is another good example of the `zip` or `roundrobin` method:
+
+```raku
+sub encrypt-squarely( $message ) {
+    roundrobin(
+      $message
+      .subst(' ', '', :g)
+      .lc
+      .comb(/ . **! {1..8} /)
+      .map({ .split('', :skip-empty) })
+    )
+    .map({ .join })
+}
+```
+
+As you can see, after removing spaces and converting to lowercase, `$message` is partitioned with `.comb` using a regex. It's then split into characters before `roundrobin` can do its magic.
+
+## Noud Aldenhoven
+
+[Noud Aldenhoven's solution](https://github.com/manwar/perlweeklychallenge-club/blob/master/challenge-045/noud/raku/ch-1.p6) once again uses `[Z~]` to make short work of this problem:
+
+```raku
+sub encode($str) {
+    my $stripped = $str.lc.subst(/\s/, '', :g);
+    my @r = ($stripped ~ " " x (8 - $stripped.chars % 8)).comb.rotor(8, :partial);
+    return ([Z~] @r).map({ $_.trim }).join(' ');
+}
+```
+
+## Roger Bell West
+
+[Roger Bell West's solution](https://github.com/manwar/perlweeklychallenge-club/blob/master/challenge-045/roger-bell-west/raku/ch-1.p6) first joins the input into `$in`:
+
+```raku
+my $n=8;
+my $in='';
+for lines() {
+  .chomp;
+  my $t=$_;
+  $t ~~ s:g/\s+//;
+  $in~=$t;
+}
+```
+
+From there, Roger's nested loop advances `$n = 8` characters at a time, from all 8 starting positions, to build up the output one character at a time:
+
+```raku
+my $l=chars($in)-1;
+my @out;
+for (0..$n-1) -> $c {
+  my $out;
+  my $k=$c;
+  while ($k <= $l) {
+    $out~=substr($in,$k,1);
+    $k+=$n;
+  }
+  push @out,$out;
+}
+
+say @out.join(' ');
+```
+
+## Ruben Westerberg
+
+[Ruben Westerberg's solution](https://github.com/manwar/perlweeklychallenge-club/blob/master/challenge-045/ruben-westerberg/raku/ch-1.p6) is a beautiful example of the `[Z~]` method:
+
+```raku
+my $string="The quick brown fox jumps over the lazy dog";
+my $padded=$string.trans(" "=>"");
+my $a=$padded.comb.rotor: 8;
+put ([Z~] $a).join: " ";
+```
+
+While we're all sometimes tempted to chain together as many things as possible, Ruben's code is an excellent case study on why it's sometimes better to split those long chains into separate statements.
+
+## Ryan Thompson
+
+[My solution](https://github.com/manwar/perlweeklychallenge-club/blob/master/challenge-045/ryan-thompson/raku/ch-1.p6) uses the `.comb` and modulo arithmetic approach:
+
+```raku
+my @s;
+$plain.lc.subst(/\s/,'',:g).comb.kv.map: { @s[$^i % $width] ~= $^str };
+@s.join(' ')
+```
+
+I used `.kv` so I could conveniently access both the character and its index.
+
+**Blog** › [Square Secret Code](http://www.ry.ca/2020/01/square-secret-code/)
+
+
+## Simon Proctor
+
+[Simon Proctor's solution](https://github.com/manwar/perlweeklychallenge-club/blob/master/challenge-045/simon-proctor/raku/ch-1.p6) gives us an encoder and decoder using `roundrobin`, and packages this up in two `multi` main subs. Here's the encoder:
+
+```raku
+#| Given a string encoded it using the square code
+multi sub MAIN(
+    *@clear-text #= Phrase to encode
+) {
+    roundrobin( @clear-text.map(*.lc.comb).flat.rotor( 8, :partial ) ).map(*.join("")).join(" ").say;
+}
+```
+
+And here is the decoder:
+
+```raku
+#| Given a square encoded string decode it
+multi sub MAIN(
+    Bool :d(:$decode)!, #= Turn on decode mode
+    *@encoded #= Encoded phrase
+) {
+    roundrobin( @encoded.map(*.comb("")) ).flat.join("").say;
+}
+```
+
+This is the first example of a decoder we've seen in Raku, and I'm impressed by how simple it turns out to be for Simon.
+
+## Ulrich Rieke
+
+[Ulrich Rieke's solution](https://github.com/manwar/perlweeklychallenge-club/blob/master/challenge-045/ulrich-rieke/raku/ch-1.p6) partitions the string using `.rotor`, and then uses `substr` in a nested loop to build up `$encoded` character by character:
+
+```raku
+sub convertString( Str $str is copy ) {
+    $str ~~ s:g/\s+// ;
+    my @strings = $str.comb.rotor( 8, :partial).map( {.join} ).Array ;
+    my $encoded ;
+    for (0..7) -> $i {
+        for @strings -> $word {
+            my $len = $word.chars ;
+            $encoded ~= $word.substr( $i , 1 ) if $len > $i ;
+        }
+    }
+    my $len = @strings.elems ;
+```
+
+At this point, we have the characters in the right order, but each column needs to now be separated by spaces:
+    
+```raku
+    my $lastwordlen = @strings[$len - 1].chars ;
+    my @cycle ;
+    for (1..$lastwordlen) {
+        @cycle.push( $len ) ;
+    }
+    for ( 1..8 - $lastwordlen) {
+        @cycle.push( $len - 1 ) ;
+    }
+    return $encoded.comb.rotor( @cycle ).map( {.join} ).Array ;
+}
+```
+
+Ulrich accomplishes this by building up an array `@cycle` to contain the length of the string in each column. He is then able to pass that to `rotor` to split `$encoded` at the correct intervals.
+
+
+*** ***
+
+# Task #2 - Source Dumper {#task2}
+
+Write a script that dumps its own source code. For example, say, the script name is `ch-2.p6`. The following command should return nothing:
+
+```sh
+$ perl6 ch-2.p6 | diff - ch-2.p6
+```
+
+***
+
+## My observations
+
+There are two ways to interpret this problem, resulting in very different solutions.
+
+### 1. Source Code Reader
+
+A straight reading of the challenge, with no additional constraints, means our script can simply read its own source file and print it. For example, here is my first solution:
+
+```raku
+$*PROGRAM.lines».say
+```
+
+Literally everyone implemented something similar.
+
+### 2. Quine
+
+However, one of the hackers this week has the perhaps dubious distinction of taking the task a step further, being the only Raku hacker this week to produce a full [quine](https://en.wikipedia.org/wiki/Quine_(computing)). That hacker is also the one writing this review.
+
+For the uninitiated, quines are computer programs that not only produce a copy of their own source code, but they also have the additional constraint of *taking no input,* meaning, reading your own source code is not allowed.
+
+Several of the Perl solutions this week were quines, so if you'd like to see more examples, check out my [Perl review](/blog/review-challenge-045#task2) for a showcase.
+
+
+## Arne Sommer
+
+[Arne Sommer's solution](https://github.com/manwar/perlweeklychallenge-club/blob/master/challenge-045/arne-sommer/raku/ch-2.p6) uses the compile-time `$?FILE` variable to get the script name, then converts it to an IO object, and `.slurp`s its contents:
+
+```raku
+print $?FILE.IO.slurp;
+```
+
+**Blog** › [Square Dumper with Raku](https://raku-musings.com/square-dumper.html)
+
+
+## Burkhard Nickels
+
+[Burkhard Nickels's solution](https://github.com/manwar/perlweeklychallenge-club/blob/master/challenge-045/burkhard-nickels/raku/ch-2.p6) is not quite as feature-packed as [his Perl version](https://github.com/manwar/perlweeklychallenge-club/blob/master/challenge-045/burkhard-nickels/perl/ch-2.pl), but Chuck still produces a complete program:
+
+```raku
+# print "ch-2.p6 - PWC #45 Task #2: Source Dumper\n";
+# print $*PROGRAM, ", ", $*PROGRAM-NAME, "\n";
+
+my $fh = open :r, $*PROGRAM;
+
+my $str;
+while ( ! $fh.eof; ) {
+    $str = $fh.get;
+    $str.print; print "\n";
+}
+$fh.close;
+```
+
+Chuck uses `$*PROGRAM` to get the `IO::Path` object of the program.
+
+**Blog** › [Source Dumper](https://github.com/manwar/perlweeklychallenge-club/blob/master/challenge-045/burkhard-nickels/perl/ch-2.pod)
+
+## Colin Crain
+
+[Colin Crain's solution](https://github.com/manwar/perlweeklychallenge-club/blob/master/challenge-045/colin-crain/raku/ch-2.p6) again uses `$*PROGRAM`, but avoids the loop by reading the contents into a string with `slurp`:
+
+```raku
+sub MAIN () {
+    print $*PROGRAM.open.slurp.gist;
+}
+```
+
+## Jaldhar H. Vyas
+
+[Jaldhar H. Vyas' solution](https://github.com/manwar/perlweeklychallenge-club/blob/master/challenge-045/jaldhar-h-vyas/raku/ch-2.p6) is another slurpy one:
+
+```raku
+open(:r, $*PROGRAM).slurp.print;
+```
+
+**Blog** › [Perl Weekly Challenge Week 45](https://www.braincells.com/perl/2020/02/perl_weekly_challenge_week_45.html)
+
+## Javier Luque
+
+[Javier Luque's solution](https://github.com/manwar/perlweeklychallenge-club/blob/master/challenge-045/javier-luque/raku/ch-2.p6) instead uses `$*PROGRAM-NAME.IO` to get the IO object needed to print the lines:
+
+```raku
+sub MAIN () {
+    for $*PROGRAM-NAME.IO.lines -> $line {
+        say $line;
+    }
+}
+```
+
+**Blog** › [PERL WEEKLY CHALLENGE – 045 – Perl Weekly Challenge](https://perlchallenges.wordpress.com/2020/01/30/perl-weekly-challenge-045/)
+
+## Jan Ole Kraft
+
+[Jan Ole Kraft's solution](https://github.com/manwar/perlweeklychallenge-club/blob/master/challenge-045/jokraft/raku/ch-2.p6) is another example of using the compile-time variable `$?FILE`. Instead of using `.IO`, the more explicit `.open` is used. After that, `readchars` reads up to 64KiB characters, and `prints` those:
+
+```raku
+IO::Path.new($?FILE).open().readchars().print();
+```
+
+The 64KiB number comes from `$*DEFAULT-READ-ELEMS`, which is 65536 on my version, but [the documentation](https://docs.perl6.org/routine/readchars) notes it is implementation-specific, so, if in doubt, supply your own value or read in a loop to avoid surprises.
+
+## Laurent Rosenfeld
+
+[Laurent Rosenfeld's solution](https://github.com/manwar/perlweeklychallenge-club/blob/master/challenge-045/laurent-rosenfeld/raku/ch-2.p6) pulls the filename from `$?FILE` uses the `IO` role of Str to enable `slurp`ing its contents:
+
+```raku
+$?FILE.IO.slurp.say;
+```
+
+**Blog** › [Perl Weekly Challenge 45: Square Secret Code and Source Dumper](http://blogs.perl.org/users/laurent_r/2020/02/perl-weekly-challenge-45-square-secret-code-and-source-dumper.html)
+
+## Luca Ferrari
+
+[Luca Ferrari's solution](https://github.com/manwar/perlweeklychallenge-club/blob/master/challenge-045/luca-ferrari/raku/ch-2.p6) uses the ready-made `$*PROGRAM` IO object to `say` each line:
+
+```raku
+sub MAIN {
+    .say for $*PROGRAM.lines;
+}
+```
+
+**Blog** › [Perl Weekly Challenge 45: encoded messages and self-source-code-printing](https://fluca1978.github.io/2020/01/29/PerlWeeklyChallenge45.html)
+
+## Markus Holzer
+
+[Markus Holzer's solution](https://github.com/manwar/perlweeklychallenge-club/blob/master/challenge-045/markus-holzer/raku/ch-2.p6) goes with `$*PROGRAM-NAME`, but the effect is the same as using `$?FILE`:
+
+```raku
+$*PROGRAM-NAME.IO.slurp.say;
+```
+
+
+## Noud Aldenhoven
+
+[Noud Aldenhoven's solution](https://github.com/manwar/perlweeklychallenge-club/blob/master/challenge-045/noud/raku/ch-2.p6) is another `$?FILE` solution:
+
+```raku
+$?FILE.IO.slurp.trim.say;
+```
+
+
+## Roger Bell West
+
+[Roger Bell West's solution](https://github.com/manwar/perlweeklychallenge-club/blob/master/challenge-045/roger-bell-west/raku/ch-2.p6) uses the more explicit `open` symtax:
+
+```raku
+my $f=open :r,$*PROGRAM-NAME;
+for $f.lines {
+  say $_;
+}
+```
+
+
+## Ruben Westerberg
+
+[Ruben Westerberg's solution](https://github.com/manwar/perlweeklychallenge-club/blob/master/challenge-045/ruben-westerberg/raku/ch-2.p6) uses `$*PROGRAM`:
+
+```raku
+$*PROGRAM.IO.lines.map: *.put;
+```
+
+## Ryan Thompson
+
+[My file read solution](https://github.com/manwar/perlweeklychallenge-club/blob/master/challenge-045/ryan-thompson/raku/ch-2.p6) uses `$*PROGRAM`, and a hyper operator to call `.say` on each line:
+
+```raku
+$*PROGRAM.lines».say
+```
+
+However, I also submitted a [full quine](https://github.com/manwar/perlweeklychallenge-club/blob/master/challenge-045/ryan-thompson/raku/ch-2a.p6):
+
+```raku
+{.printf($_)}(<{.printf($_)}(<%s>)>)
+```
+
+You can see that the `<>` quote contains a copy of the program, and the `printf` will duly expand the `%s`, so the output is the full program source, and passes the `diff` test as well.
+
+**Blog** › [Quine](http://www.ry.ca/2020/02/quine/)
+
+
+## Simon Proctor
+
+[Simon Proctor's solution](https://github.com/manwar/perlweeklychallenge-club/blob/master/challenge-045/simon-proctor/raku/ch-2.p6) `slurps` right from `$*PROGRAM`:
+
+```raku
+$*PROGRAM.slurp.print;
+```
+
+## Ulrich Rieke
+
+[Ulrich Rieke's solution](https://github.com/manwar/perlweeklychallenge-club/blob/master/challenge-045/ulrich-rieke/raku/ch-2.p6) is another example of a more explicit approach with `open`:
+
+```raku
+my $fh = open $?FILE , :r ;
+.say for $fh.lines ;
+close $fh ;
+```
+
+
+***
+***
+
+## SEE ALSO {#blogs}
+
+***
+
+### Blogs this week:
+
+
+
+**Adam Russell** › [Perl Fun](https://adamcrussell.livejournal.com/15213.html)
+
+**Arne Sommer** › [Square Dumper with Raku](https://raku-musings.com/square-dumper.html)
+
+**Burkhard Nickels** › [Square Secret Code](https://github.com/manwar/perlweeklychallenge-club/blob/master/challenge-045/burkhard-nickels/perl/ch-1.pod) | [Source Dumper](https://github.com/manwar/perlweeklychallenge-club/blob/master/challenge-045/burkhard-nickels/perl/ch-2.pod)
+
+**Dave Jacoby** › [Challenge 45: Cyphers and Quines](https://jacoby.github.io/2020/01/29/challenge-45-cyphers-and-quines.html)
+
+**E. Choroba** › [Square Secret Code & Source Dumper](http://blogs.perl.org/users/e_choroba/2020/01/perl-weekly-challenge-045-square-secret-code-source-dumper.html)
+
+**Jaldhar H. Vyas** › [Perl Weekly Challenge 45](https://www.braincells.com/perl/2020/02/perl_weekly_challenge_week_45.html)
+
+**Javier Luque** › [Perl Weekly Challenge](https://perlchallenges.wordpress.com/2020/01/30/perl-weekly-challenge-045/)
+
+**Luca Ferrari** › [encoded messages and self-source-code-printing](https://fluca1978.github.io/2020/01/29/PerlWeeklyChallenge45.html)
+
+**Laurent Rosenfeld** › [Square Secret Code and Source Dumper](http://blogs.perl.org/users/laurent_r/2020/02/perl-weekly-challenge-45-square-secret-code-and-source-dumper.html)
+
+**Ryan Thompson** › [Square Secret Code](http://www.ry.ca/2020/01/square-secret-code/) | [Quine](http://www.ry.ca/2020/02/quine/)

--- a/content/blog/review-challenge-045.md
+++ b/content/blog/review-challenge-045.md
@@ -1,0 +1,1343 @@
+---
+author: "Ryan Thompson"
+date: 2020-02-06T21:50:43
+description: "Ryan Thompson › Perl Weekly Review: Challenge - #045"
+tags: ["perl"]
+title: "Ryan Thompson › Perl Weekly Review: Challenge - #045"
+type: post
+---
+
+Welcome to the Perl review for Week 045 of the Weekly Challenge! For a quick overview, go through the [original tasks](/blog/perl-weekly-challenge-045/) and [recap](/blog/recap-challenge-045/) of the weekly challenge.
+
+Continues from [previous week](/blog/review-challenge-044/).
+
+## Getting in Touch
+
+<a href="mailto:rjt@cpan.org"><img src="http://ry.ca/misc/Email.svg" height="50" width="50"> Email</a> › Email me (Ryan) with any feedback about this review.
+
+<a href="https://github.com/manwar/perlweeklychallenge"><img src="http://ry.ca/misc/Github.svg" height="50" width="50"> GitHub</a> › Submit a pull request for any issues you may find with this page.
+
+<a href="https://twitter.com/perlwchallenge"><img src="http://ry.ca/misc/Twitter.svg" height="50" width="50"> Twitter</a> › Join the discussion on Twitter!
+
+We'd greatly appreciate any feedback you'd like to give.
+
+## Table of Contents
+
+ * [Task 1](#task1)
+ * [Task 2](#task2)
+ * [Blogs](#blogs)
+
+
+***
+***
+
+# Task #1 › Square Secret Code {#task1}
+
+***
+
+## Original task description
+
+The square secret code mechanism first removes any space from the original message. Then it lays down the message in a row of 8 columns. The coded message is then obtained by reading down the columns going left to right.
+
+For example, the message is **“The quick brown fox jumps over the lazy dog”.**
+
+Then the message would be laid out as below:
+
+```
+thequick
+brownfox
+jumpsove
+rthelazy
+dog
+```
+**Figure 1** › Partitioned Plaintext
+
+The code message would be as below:
+
+```
+tbjrd hruto eomhg qwpe unsl ifoa covz kxey
+```
+
+***
+
+## My general observations
+
+There seem to be two main ways people approached this task:
+
+### 1. Partitioning
+
+By first splitting the plaintext into column-width substrings, you end up with **Figure 1** (above). From there, you can simply append the first character of each string to your output, then the second character, and so on.
+
+This method is perhaps the most obvious implementation of the problem description, as it follows the wording quite closely.
+
+### 2. `split` and Modulo Arithmetic
+
+For this method, you first `split` the plaintext into a list of chars. Then, you loop over the plaintext array, appending each character into its `$index % $columns` string in an array of `@columns`. Finally, you simply `join` the columns together.
+
+This method is maybe a little less obvious, but lead to some concise solutions.
+
+***
+
+If my plain English descriptions don't make complete sense yet, don't worry; there will be plenty of code examples of both methods below. 
+
+## Adam Russell
+
+[Adam Russell's solution](https://github.com/manwar/perlweeklychallenge-club/blob/master/challenge-045/adam-russell/perl/ch-1.pl) uses the `split` and modulo arithmetic method. He iterates over `@characters` to `push` characters into the array of arrays, `@buckets`:
+
+```perl
+use constant SQUARE_SIZE => 8;
+sub encode{
+    my($message) = @_;
+    $message =~ tr/ //d;
+    my $encoded;
+    my @buckets;
+    my @characters = split(//, lc($message));
+    for my $i (0 .. @characters){
+       $buckets[$i % SQUARE_SIZE] = [] if !$buckets[$i % SQUARE_SIZE];
+       push @{$buckets[$i % SQUARE_SIZE]}, $characters[$i] if $characters[$i];  
+    } 
+    for my $bucket (@buckets){
+        $encoded .= join("", @{$bucket}) . " ";
+    }  
+    return $encoded; 
+}
+```
+
+The solution is then built up by joining each of the `@buckets` together, and appending the result to the `$encoded` output string, with the space to separate the columns.
+
+**Blog** › [Perl Fun](https://adamcrussell.livejournal.com/15213.html)
+
+## Alicia Bielsa
+
+[Alicia Bielsa's solution](https://github.com/manwar/perlweeklychallenge-club/blob/master/challenge-045/alicia-bielsa/perl/ch-1.pl) has an input loop that asks the user for a plaintext message. Her `encodeMessage` function uses the `split` and modulo method to encode the message:
+
+```perl
+sub encodeMessage {
+    my $message = shift;
+    my @aSubMessages = ();
+    my $messageEncoded = '';
+    $message =~ s%\s+%%g;
+    my @aEncodedGroups = ();
+    my @aMessage = split ('', $message);
+    foreach my $indexMessage  (0..$#aMessage) {
+        my $indexSubgroup = $indexMessage % $columnLength ;
+        unless  (defined $aEncodedGroups[$indexSubgroup]) {
+            $aEncodedGroups[$indexSubgroup] = '';
+        }
+        $aEncodedGroups[$indexSubgroup] .= $aMessage[$indexMessage]; #t
+    }
+    $messageEncoded = join(' ', @aEncodedGroups);
+    return $messageEncoded ;
+}
+```
+
+The `$indexSubgroup = $indexMessage % $columnLength` line is what sets up the proper index, so that the next character in `@aMessage` is appended to the correct column in `@aEncodedGroups`.
+
+Also notable, is that Alicia is one of a few people who allows for a configurable column width, through the `$columnLength` variable, which is a thoughtful touch.
+
+## Andrezgz
+
+[Andrezgz's solution](https://github.com/manwar/perlweeklychallenge-club/blob/master/challenge-045/andrezgz/perl/ch-1.pl) first converts the input to lowercase, and then filters out any remaining non-lowercase characters (such as numerics, symbols, and spaces):
+
+```perl
+my $msg = join '',
+          map {my $w = lc $_; $w =~ s/[[:^lower:]]//g; $w }
+          @ARGV or die "USAGE: $0 <message>";
+```
+
+After that, the solution is built up in a `%cols` hash with modulo arithmetic, with one member for each column:
+
+```perl
+my %cols;
+# each letter is appended to the corresponding column
+$cols{$_ % 8} .= substr $msg, $_, 1 for (0 .. (length $msg) -1 );
+
+# coded message is formed by printing each column string in order
+print join ' ', map { $cols{$_} } sort keys %cols;
+```
+
+This is a really clean solution, and I particularly like the decision to filter out characters based on what is *allowed,* instead of what isn't. When possible, this method typically leads to safer, less error-prone code, as the programmer doesn't have to account for every possible thing a user might throw at them.
+
+## Arne Sommer
+
+Arne has submitted excellent Raku solutions for *all* 45 weeks in the challenge so far, which is absolutely fantastic. But this is, I believe, the first week Arne has submitted a Perl solution since all the way back in Week 023. Welcome back!
+
+[Arne Sommer's solution](https://github.com/manwar/perlweeklychallenge-club/blob/master/challenge-045/arne-sommer/perl/ch-1.pl) is straightforward:
+
+```perl
+my $string = $ARGV[0] || "The quick brown fox jumps over the lazy dog";
+$string =~ tr/ //d;
+my @a = split(//, lc $string);
+
+@a.shift;
+@a.pop;
+
+for my $word (0 .. 7) {
+  my $index = $word;
+  while (1) {
+    defined $a[$index]
+      ? print $a[$index]
+      : print(" ") && last;
+
+   $index += 8;
+  }
+}
+print "\n";
+```
+
+One minor issue, is that the `@a.shift;` and `@a.pop;` lines aren't necessary, and in fact, these statements do nothing except some string concatenation in void context (which would have thrown a warning with `use warnings` enabled). On reading his blog, Arne was getting extra characters somehow, but that appears to no longer be the case, as this solution works perfectly. It's also very easy to understand.
+
+Again, I'm very glad to see Arne submitting Perl solutions, and hope to see more in the future! If you haven't already been following his blog, please do so; it's excellent.
+
+**Blog** › [Square Dumper with Raku](https://raku-musings.com/square-dumper.html)
+
+## Athanasius
+
+[Athanasius's solution](https://github.com/manwar/perlweeklychallenge-club/blob/master/challenge-045/athanasius/perl/ch-1.pl) also has an input loop, and the encoder uses the partitioning method:
+
+```perl
+sub encode {
+    my  ($plain)  = @_;
+    my   @rows;
+    push @rows, substr($plain, 0, $COLUMNS, '') while $plain;
+    my   $encoded = '';
+
+    for my $col (0 .. $COLUMNS - 1) {
+        $encoded .= ' ' if $encoded;
+
+        for my $row (0 .. $#rows) {
+            my $text  = $rows[$row];
+            $encoded .= substr($text, $col, 1) if $col < length $text;
+        }
+    }
+
+    return $encoded;
+}
+```
+
+As you can see, `@rows` is built up by partitioning `$plain` into chunks of up to `$COLUMN` characters. (The fourth argument to `substr` (`''`) is the replacement text, so those chunks get removed during the loop). The next two nested loops build up `$encoded` character by character from the strings in `@rows`.
+
+Athanasius wrote a decoder as well:
+
+```perl
+sub decode {
+    my ($encoded) = @_;
+    my  @rows     = split /\s+/, $encoded;
+    my  $decoded  = '';
+
+    for my $col (0 .. length($rows[0]) - 1) {
+        $decoded .= substr($rows[$_], $col, 1) for 0 .. $#rows;
+    }
+
+    return $decoded;
+}
+```
+
+The decoder is a little simpler as Athanasius was able to take advantage of the encoded format having spaces separating the rows, but the meat of the function is similar: the nested loops are essentially doing the inverse of what `encode` did, above.
+
+## Burkhard Nickels
+
+[Burkhard Nickels' solution](https://github.com/manwar/perlweeklychallenge-club/blob/master/challenge-045/burkhard-nickels/perl/ch-1.pl) first `split`s the plaintext into a character array, `@l`. Then, Burkhard uses a nested loop that builds up the result (`$coded_msg`) by calculating the array indicies:
+
+```perl
+$msg =~ s/\s//g;
+$msg = lc($msg);
+my @l = split("",$msg);
+
+my $coded_msg;
+for(my $i=0; $i<=7; $i++) {
+    for(my $j=$i; $j<=$#l; $j+=8) {
+        $coded_msg .= $l[$j];
+    }
+    $coded_msg .= " ";
+}
+print "Coded   : $coded_msg\n";
+```
+
+The C-style `for` loops allow Burkhard to manipulate the starting index and increment of the inner loop, so `$j` will always be the next index to be appended to the result.
+
+### Python
+
+Burkhard also submitted a [Python solution](https://github.com/manwar/perlweeklychallenge-club/blob/master/challenge-045/burkhard-nickels/python/ch-1.py). Here's the encoder:
+
+```python
+msg = re.sub('\s','',msg)
+msg = msg.lower()
+l = list(msg)
+
+coded_msg = ""
+for i in range(0,8):
+    j = i
+    e = len(l)
+    while j < e:
+        coded_msg += l[j]
+        j += 8
+    coded_msg += " "
+
+print "Coded   : ", coded_msg
+```
+
+The Python code uses the same algorithm as the above Perl solution.
+
+**Blog** › [Square Secret Code](https://github.com/manwar/perlweeklychallenge-club/blob/master/challenge-045/burkhard-nickels/perl/ch-1.pod)
+
+## Cheok-Yin Fung
+
+[Cheok-Yin Fung's solution](https://github.com/manwar/perlweeklychallenge-club/blob/master/challenge-045/cheok-yin-fung/perl/ch-1.pl) decomposes the problem into three distinct parts. First, the plaintext is sanitized, and padded to be a multiple of 8 characters:
+
+```perl
+$msg = lc($msg);
+$msg =~ s/\s//g; # &removespace($_);
+$msg =~ s/\t//g;
+
+#ADD WHITESPACE AT THE END SUCH THAT THE LINE HAS 8n CHARACTERS
+my $copyoflengthofmsg = length($msg);
+$msg .= " " x ($copyoflengthofmsg % 8);
+```
+
+Second, the plaintext is split into characters, and put into a two-dimensional array. `$i` and `$j` are maintained such that `@a` will have the characters in the same type of grid shown in the challenge description:
+
+```perl
+my $numberofcols = 8;
+
+foreach my $char (split //, $msg) {
+    $a[$i][$j] = $char;
+        $copyoflengthofmsg++;
+    $j++;
+    if ($j==$numberofcols) {$j = 0; $i++;}
+}
+```
+
+Finally, Cheok-Yin Fung iterates over the `@a` grid to print out the solution:
+
+```perl
+for $j (0..$numberofcols) {
+    for $i (0..7) {
+        $b[$p] = $a[$i][$j];
+        if ($b[$p] ne " ") {print $b[$p];}
+        $p++;
+    }
+    print " ";
+}
+```
+
+## Colin Crain
+
+[Colin Crain's solution](https://github.com/manwar/perlweeklychallenge-club/blob/master/challenge-045/colin-crain/perl/ch-1.pl) `split`s and uses modulo arithmetic:
+
+```perl
+## eliminate spaces and nonword chars, lowercase rest in one pass
+$input = lc( join '', grep { /\w/ } split //, $input );
+
+## create the output array data structure
+push my @output, [] for (1..8);
+
+## fill the output arrays
+push $output[$_%8]->@*, substr $input, ($_), 1  for (0..(length $input) - 1);
+
+## display the output arrays
+say join ' ', map {join '', $_->@* } @output;
+```
+
+This is an example of a good way to use the [post-deref](https://perldoc.perl.org/perlref.html#Postfix-Dereference-Syntax) syntax, in my opinion; it actually aids the comprehension in this case. Colin's solution is compact, without being hard to follow.
+
+## Dave Cross
+
+[Dave Cross' solution](https://github.com/manwar/perlweeklychallenge-club/blob/master/challenge-045/dave-cross/perl/ch-1.pl) outputs the result in the loop body, rather than building up a string first, but the result is the same:
+
+```perl
+$msg =~ s/\s+//g;
+
+my @lines = map { [ split // ] } $msg =~ /(.{1,8})/g;
+
+for my $x (0 .. $#{$lines[0]}) {
+  for my $y (0 .. $#lines) {
+    print $lines[$y][$x] // '';
+  }
+  print ' ';
+}
+
+print "\n";
+```
+
+Dave partitions `$msg` into 8 character (or less) chunks with a `/g` regex in list context, so it can be sent straight to `map`, where it is then split into characters and stored in an array of arrays.
+
+## Dave Jacoby
+
+[Dave Jacoby's solution](https://github.com/manwar/perlweeklychallenge-club/blob/master/challenge-045/dave-jacoby/perl/ch-1.pl) first filters out any non-lowercase characters, and then starts partitioning `$plaintext` into chunks of 8 characters or less, using `substr` and regexp substitution:
+
+```perl
+sub encypher ( $plaintext ) {
+    $plaintext = lc $plaintext;
+    $plaintext =~ s/[^a-z]//gmx;
+    my @work;
+
+    while ( length $plaintext >= 8 ) {
+        my $eight = substr $plaintext, 0, 8;
+        $plaintext =~ s/\w{8}//mix;
+        push @work, $eight;
+    }
+    push @work, $plaintext;
+
+    my @cyphertext;
+
+    for my $i ( 0 .. scalar @work - 1 ) {
+        my $word = $work[$i];
+        for my $j ( 0 .. length $word ) {
+            my $letter = substr $word, $j, 1;
+            next unless scalar $letter;
+            $cyphertext[$j][$i] = $letter;
+        }
+    }
+
+    return join ' ', map { join '', $_->@* } @cyphertext;
+}
+```
+
+After that, `@cyphertext` is a two-dimensional array (array of arrays, or AoA) built up with a by now familiar-looking nested loop. The `return` is made by sending each top-level element of `@cyphertext` through `map { join '', $_->@* }` to turn the array into a string, and then those strings are `join`ed by the leftmost `join ' '`.
+
+**Blog** › [Challenge 45: Cyphers and Quines](https://jacoby.github.io/2020/01/29/challenge-45-cyphers-and-quines.html)
+
+
+## Duane Powell
+
+[Duane Powell's solution](https://github.com/manwar/perlweeklychallenge-club/blob/master/challenge-045/duane-powell/perl/ch-1.pl) is concise and clear:
+
+```perl
+$code =~ s/ //g;
+my @code = split(//,$code);
+
+my @out;
+my $m = 0;
+$out[$m++ % $block] .= shift(@code) while (@code);
+print "$_ " foreach (@out);
+print "\n";
+```
+
+The line doing the heavy lifting, `$out[$m++ % $block] .= shift(@code) while (@code)` is another good example of how modulo arithmetic really makes light work of this problem.
+
+
+## Duncan C. White
+
+[Duncan C. White's solution](https://github.com/manwar/perlweeklychallenge-club/blob/master/challenge-045/duncan-c-white/perl/ch-1.pl) provides both an encoder and decoder, as well as a way to change the number of columns. The encoder uses the modulo arithmetic method, but replaces the `split` with repeated calls to `substr $text, $pos, 1` to get one character at a time:
+
+```perl
+use Function::Parameters;
+
+fun encode( $text )
+{
+    my @columns;
+    $text =~ s/\s+//g;        # remove all whitespace
+    my $len = length($text);
+    foreach my $pos (0..$len-1) {
+        my $ch = substr($text,$pos,1);
+        $columns[$pos%$ncolumns] //= "";
+        $columns[$pos%$ncolumns] .= $ch;
+    }
+    my $result = join( ' ', @columns );
+    return $result;
+}
+```
+
+The decoder splits the ciphertext on whitespace to obtain `@columns`. After that is a nested loop, whose body uses `s/(^\w)//` to trim (and capture) the first character from one of the `@columns`, appending it to the result:
+
+```perl
+fun decode( $text )
+{
+    my @columns = split( /\s+/, $text );
+    my $ncols = @columns;
+    die "decode: $text has $ncols columns, not $ncolumns\n"
+        unless $ncols == $ncolumns;
+    my $npasses = length( $columns[0] );
+    my $result = "";
+    foreach my $p (1..$npasses) {
+        foreach (@columns) {
+            if( $_ ) {
+                s/(^\w)//;    # remove 1st char from column
+                $result .= $1;
+            }
+        }
+    }
+    return $result;
+}
+```
+
+## E. Choroba
+
+[E. Choroba's solution](https://github.com/manwar/perlweeklychallenge-club/blob/master/challenge-045/e-choroba/perl/ch-1.pl):
+
+```perl
+sub square_secret_code {
+    my ($message) = @_;
+    my @code = ("") x 8;
+    for my $group (lc($message) =~ s/\s//gr =~ m/(.{1,8})/g) {
+        $code[$_] .= (split //, $group)[$_] // "" for 0 .. 7;
+    }
+    return join ' ', @code
+}
+```
+
+This solution is another example of using the `/g` modifier in list context. However, Choroba does one better and first removes spaces with the substitution `s/\s//gr`. The `/r` modifier is a personal favourite of mine, as instead of performing the substitution in place as usual, it returns a copy of the (modified) string instead. Without that, Choroba would have needed an extra couple of lines of code.
+
+**Blog** › [Perl Weekly Challenge 045: Square Secret Code & Source Dumper](http://blogs.perl.org/users/e_choroba/2020/01/perl-weekly-challenge-045-square-secret-code-source-dumper.html)
+
+## Jaldhar H. Vyas
+
+[Jaldhar H. Vyas' solution](https://github.com/manwar/perlweeklychallenge-club/blob/master/challenge-045/jaldhar-h-vyas/perl/ch-1.pl) chunks the plaintext into `@rows` of 8 characters, and then uses a nested loop to append the `$i`th character from each row to the `$i`th column. The solution is then just `@cols`, separated by spaces:
+
+```perl
+my $input = lc join q{ }, @ARGV;
+$input =~ s/\s+//gmx;
+my @rows;
+while (length $input) {
+    push @rows, substr $input, 0, 8, q{};
+}
+
+my @cols;
+for my $row (@rows) {
+    my @chars = split //, $row;
+    for my $i (0 .. 7) {
+        if ($chars[$i]) {
+            $cols[$i] .= $chars[$i];
+        }
+    }
+}
+
+say join q{ }, @cols;
+```
+
+**Blog** › [Perl Weekly Challenge: Week 45](https://www.braincells.com/perl/2020/02/perl_weekly_challenge_week_45.html)
+
+## Javier Luque
+
+[Javier Luque's solution](https://github.com/manwar/perlweeklychallenge-club/blob/master/challenge-045/javier-luque/perl/ch-1.pl) is another concise one with modulo arithmetic:
+
+```perl
+$string =~ s/\s//g;
+my @chars = split('', $string);
+my @new_words;
+
+for my $i (0..scalar(@chars)-1) {
+    $new_words[$i % 8] .= $chars[$i];
+}
+
+say join ' ', @new_words;
+```
+
+**Blog** › [PERL WEEKLY CHALLENGE – 045 – Perl Weekly Challenge](https://perlchallenges.wordpress.com/2020/01/30/perl-weekly-challenge-045/)
+
+## Laurent Rosenfeld
+
+[Laurent Rosenfeld's solution](https://github.com/manwar/perlweeklychallenge-club/blob/master/challenge-045/laurent-rosenfeld/perl/ch-1.pl) uses the partition approach, printing the output on the fly:
+
+```perl
+$msg =~ s/\s+//g;
+my @letters = map { /.{1,8}/g; } $msg;
+for my $i (0..7) {
+    print map { substr  $_, $i, 1 if length $_ >= $i} @letters;
+    print " ";
+}
+```
+
+**Blog** › [Perl Weekly Challenge 45: Square Secret Code and Source Dumper](http://blogs.perl.org/users/laurent_r/2020/02/perl-weekly-challenge-45-square-secret-code-and-source-dumper.html)
+
+## Maxim Kolodyazhny
+
+[Maxim Kolodyazhny's solution](https://github.com/manwar/perlweeklychallenge-club/blob/master/challenge-045/maxim-kolodyazhny/perl/ch-1.pl) is a unique one:
+
+```perl
+$_ = lc <>;
+s/\s//g;
+
+for my $i ( 0..7 ) {
+    last if ( pos = $i ) == length;
+    print
+        $i ? ' ' : '',
+        /(.).{0,7}/g;
+}
+```
+
+Take careful note of Maxim's assignment to `pos`, as that is the key to the entire solution. `pos` sets the offset of the regexp match, and the regexp `/(.).{0,7}/g` captures every 8th character from that offset. The offset is then incremented the next time through, and it repeats, and thus the columns are printed, one character at a time.
+
+Maxim also included an [external set of tests](https://github.com/manwar/perlweeklychallenge-club/blob/master/challenge-045/maxim-kolodyazhny/perl/t/ch-1.t).
+
+## Nazareno Delucca
+
+[Nazareno Delucca's solution](https://github.com/manwar/perlweeklychallenge-club/blob/master/challenge-045/ndelucca/perl/ch-1.pl) uses partitioning, and also allows for a user-specified column width:
+
+```perl
+my $columns = shift || 8;
+$message =~ s/\s+//g;
+my @rows = unpack "(A$columns)*", lc $message;
+
+foreach my $word ( @rows ){
+    my @chars = split //, $word;
+    push @matrix, \@chars;
+}
+
+for (0..$columns) {
+    for my $row( @matrix ) {
+        $code .= shift @$row || '';
+    }
+    $code .= " ";
+}
+
+print "$code\n";
+```
+
+The use of `unpack` is a good way to partition the string. Nazareno then splits the row strings to character arrays to simplify the following task of repeatedly peeling off the first character of each string.
+
+## Rage311
+
+[Rage311's solution](https://github.com/manwar/perlweeklychallenge-club/blob/master/challenge-045/rage311/perl/ch-1.pl) uses the `split`/modulo method, and is beautifully concise:
+
+```perl
+my @input = split //, <<>> =~ s/\s+//gr;
+
+my @words;
+$words[$_ % 8] .= $input[$_] for 0..$#input;
+
+say join ' ', @words;
+```
+
+This is, I believe, Rage311's first Perl submission. Congrats! I hope to see a lot more like this one.
+
+Rage311 also [submitted a solution in Rust](https://github.com/manwar/perlweeklychallenge-club/blob/master/challenge-045/rage311/rust/ch-1.rs), using the same algorithm. Here it is, for all you Rust fans out there:
+
+```rust
+fn main() -> io::Result<()> {
+    let mut buffer = String::new();
+    io::stdin().read_to_string(&mut buffer)?;
+    buffer = buffer.split_whitespace().collect();
+
+    let mut final_words: Vec<String> = vec!["".to_string(); 8];
+
+    for i in 0..buffer.len() {
+        final_words[i % 8].push(buffer.chars().nth(i).unwrap());
+    }
+
+    println!("{}", final_words.join(" "));
+
+    Ok(())
+}
+```
+
+## Roger Bell West
+
+[Roger Bell West's solution](https://github.com/manwar/perlweeklychallenge-club/blob/master/challenge-045/roger-bell-west/perl/ch-1.pl) uses core module [`Getopt::Std`](https://perldoc.perl.org/Getopt/Std.html) to accept an arbitrary column width:
+
+```perl
+use Getopt::Std;
+my %o=(n => 8);
+getopts('n:',\%o);
+```
+
+Then, after stripping spaces, his encoding looks like this:
+
+```perl
+my $l=length($in)-1;
+my @out;
+foreach my $c (0..$o{n}-1) {
+    my $out;
+    for (my $k=$c;$k<=$l;$k+=$o{n}) {
+        $out.=substr($in,$k,1);
+    }
+    push @out,$out;
+}
+print join(' ',@out),"\n";
+```
+
+As you can see, Roger uses a C-style `for` loop so he can increment by the column width (`$o{n}`) to pull every `$o{n}`-th character into his output array. The outer loop shifts the offset (`$c`) every time through. If speed was the goal, this could be ported to a C XS module with just a few minor changes.
+
+
+## Ruben Westerberg
+
+[Ruben Westerberg's solution](https://github.com/manwar/perlweeklychallenge-club/blob/master/challenge-045/ruben-westerberg/perl/ch-1.pl) avoids the need to deal with undefined values for strings that aren't a multiple of 8 characters in length by padding the string with spaces:
+
+```perl
+$padded .= " " x (8+8-length($padded)%8);
+```
+
+Then, he partitions and splits the string into the `@rows` array-of-arrays, and iterates over it with a nested loop:
+
+```perl
+my @rows;
+my $steps=length($padded)/ 8;
+push @rows, [split "", substr $padded, $_*8,8] for (0..$steps-1);
+my $out="";
+for my $c (0..7) {
+    for my $r (0..$steps-1) {
+        $out.= join "",$rows[$r]->[$c];
+    }
+}
+$out=~s/ +/ /g;
+$out=~s/ $//;
+print $out;
+```
+
+His padded string does require a bit of trimming at the end, but after that, all that needs be done is `print $out`. Nice.
+
+
+## Ryan Thompson
+
+[My solution](https://github.com/manwar/perlweeklychallenge-club/blob/master/challenge-045/ryan-thompson/perl/ch-1.pl) uses the split/modulo method:
+
+```perl
+sub encode {
+    local $_ = lc shift;
+    s/\s//g;
+    my ($i, @s);
+
+    map { $s[$i++ % COLUMNS] .= $_ } split '';
+
+    join ' ', @s;
+}
+```
+
+The last two lines do most of the work. Had I been going for brevity, I might have combined the `lc` and substitution regex on the same line as `split`:
+
+```perl
+sub encode {
+    my ($i, @s);
+    $s[$i++ % COLUMNS] .= $_ for split '', lc shift =~ s/\s//gr;
+    join ' ', @s
+}
+```
+
+But I didn't feel that helped the code, so I left it as separate statements. I would be happy with either, though.
+
+**Blog** › [Square Secret Code](http://www.ry.ca/2020/01/square-secret-code/)
+
+
+## Saif Ahmed
+
+[Saif Ahmed's solution](https://github.com/manwar/perlweeklychallenge-club/blob/master/challenge-045/saiftynet/perl/ch-1.pl) also supports arbitrary columns, and uses the partition method to chunk the plaintext into `@splitChars` before the familiar-looking nested loop builds up `$result` character by character:
+
+```perl
+sub pivotEncode{
+   my $str=shift;
+   my $cols=shift//8;
+   $str=~s/\s//gm;                             # remove spaces
+   @splitChars=($str=~/(.{$cols}|.+)/g);       # split into blocks
+   my $result;                                 # initialise result
+   foreach my $index (0..$cols-1) {            # now select character
+      foreach my $row ( @splitChars ){         # in each block and
+                                               # append it to result
+        $result.= substr($row,$index,1) if ($index<length $row)
+      }
+      $result.=" ";                            #intersperse spaces
+   }
+   return $result;                             # return encrypted
+}
+```
+
+## Ulrich Rieke
+
+[Ulrich Rieke's solution](https://github.com/manwar/perlweeklychallenge-club/blob/master/challenge-045/ulrich-rieke/perl/ch-1.pl) uses the partitioning method. I'll take you through his `encode` function one step at a time. First, he partitions the string (including any remaining portion less than 8 characters long):
+
+```perl
+sub encode {
+  my $str = shift ;
+  my @strings ;
+  my $times = int ( (length $str) / 8 ) ;
+  my $pos = 0 ;
+  for ( my $i = 0 ; $i < $times ; $i++ ) {
+      push @strings, substr( $str, $pos , 8 ) ;
+      $pos += 8 ;
+  }
+```
+
+At this point, `@strings` contains one string for each row. Next, Ulrich uses a nested loop and `substr($word, $i, 1)` to build up `$encoded` character by character:
+
+```perl
+  push @strings , substr( $str, $pos ) ;
+  my $encoded ;
+  for ( my $i = 0 ; $i < 8 ; $i++ ) {
+      for my $word ( @strings ) {
+    my $len = length $word ;
+    if ( $len > $i ) {
+        $encoded .= substr( $word , $i , 1 ) ;
+    }
+      }
+  }
+```
+
+By now, `$encoded` might look like `Tbjrdhrutoeomhgqwpeunslifoacovzkxey`, which is close, but needs spaces between the columns, which is what this next bit does, by splitting and then recombining via `join ' ', @encodedStrings`:
+
+```perl
+  my $stringslen = scalar @strings ;
+  my $len = length $encoded ;
+  $times =  length $strings[-1]  ;
+  my @encodedStrings ;
+  $pos = 0 ;
+  for ( my $i = 0 ; $i < $times ; $i++ ) {
+      push @encodedStrings, substr( $encoded , $pos , $stringslen ) ;
+      $pos += $stringslen ;
+  }
+  my $theRest = 8 - $times ;
+  for ( my $i = 0 ; $i < $theRest ; $i++ ) {
+      push @encodedStrings , substr( $encoded , $pos , $stringslen - 1 ) ;
+      $pos += $stringslen - 1 ;
+  }
+  return ( join ( ' ' , @encodedStrings ) ) ;
+}
+```
+
+## Wanderdoc
+
+[Wanderdoc's solution](https://github.com/manwar/perlweeklychallenge-club/blob/master/challenge-045/wanderdoc/perl/ch-1.pl) uses Leon Timmermans' [`Const::Fast`](https://metacpan.org/pod/Const::Fast) in place of builtin constants:
+
+```perl
+use Const::Fast; # To use the constant in the regex.
+const my $SECRET => 8;
+const my $REGEX => qr/(.{1,${SECRET}})/;
+```
+
+Wanderdoc then uses the partitioning method to break up the string:
+
+```perl
+sub encoding_message {
+     my $str = $_[0];
+     $str =~ tr/ //ds;
+     $str = lc $str;
+
+     my @rows = map [split(//,$_)], ($str =~ /$REGEX/g);
+     my @coded = map {
+          my $idx = $_;
+          my @slice = map $_->[$idx] // '', @rows; [@slice];
+     } 0 .. $SECRET - 1;
+
+     my $enc = join(' ', map join('',@$_), @coded);
+
+     return $enc;
+}
+```
+
+Notice that Wanderdoc uses a variation on the nested loop to create an array-of-arrays in `@coded`, that is then joined together for the solution.
+
+Wanderdoc also provides a decoder, which looks very similar to the above portion of the encoder, but in reverse:
+
+```perl
+sub decoding_message {
+     my $str = $_[0];
+     my @words = map [split(//,$_)], split(' ', $str);
+     my @txt = map {
+          my $idx = $_;
+          my @slice = map $_->[$idx] // '', @words; [@slice];
+     } 0 .. $#words;
+
+     my $dec = join('', map join('',@$_), @txt);
+}
+```
+
+***
+***
+
+# Task #2 - Source Dumper {#task2}
+
+Write a script that dumps its own source code. For example, say, the script name is `ch-2.pl`. The following command should return nothing:
+
+```sh
+$ perl ch-2.pl | diff - ch-2.pl
+```
+
+***
+
+There are two ways to interpret this problem, resulting in very different solutions. A straight reading of the challenge, with no additional constraints, means our script can simply read its own source file and print it. For example:
+
+```perl
+open my $fh, '<', __FILE__; # or $0
+print <$fh>;
+```
+
+Most people did something similar to this, and these solutions certainly pass the challenge! However, a few of us noticed that this challenge sounded an awful lot like a [quine](https://en.wikipedia.org/wiki/Quine_(computing)), so we took it a step further for (in my case) the fun of it. Quines are computer programs that not only produce a copy of their own source code, but they also have the additional constraint of *taking no input,* meaning, reading your own source code is not allowed.
+
+
+## Adam Russell
+
+[Adam Russell's solution](https://github.com/manwar/perlweeklychallenge-club/blob/master/challenge-045/adam-russell/perl/ch-2.pl) is a proper quine, because it does not use any input (the last blank line is required):
+
+```perl
+print<<''x2,"\n"
+print<<''x2,"\n"
+
+```
+
+I've previously seen this quine [attributed to Robin Houston](http://www.nyx.net/~gthompso/self_perl.txt) some years ago, and it's long been one of my favourites, due to the clever use of heredocs.
+
+**Blog** › [Perl Fun](https://adamcrussell.livejournal.com/15213.html)
+
+## Alicia Bielsa
+
+[Alicia Bielsa's solution](https://github.com/manwar/perlweeklychallenge-club/blob/master/challenge-045/alicia-bielsa/perl/ch-2.pl) uses `$0` to obtain the filename.
+
+```perl
+open (my $fh_file , '<', $0 ) or die "Error reading file";
+while (my $line = <$fh_file>) {
+     print $line;
+}
+close ($fh_file);
+```
+
+Using the three-argument `open` is [always a good practice](http://modernperlbooks.com/mt/2010/04/three-arg-open-migrating-to-modern-perl.html), so I'm glad to see Alicia use it here. It would, after all, be a terrible quine if your script was named `rm -rf . |` and used the two-argument `open` (please don't try this.)
+
+## Andrezgz
+
+[Andrezgz's solution](https://github.com/manwar/perlweeklychallenge-club/blob/master/challenge-045/andrezgz/perl/ch-2.pl) is another proper quine. The whole thing is nearly 100 lines long, but it's worth seeing, so I'll trim it down a bit (mostly removing comments) and show what's left, here. This should still be a quine, after my trimming:
+
+```perl
+use v5.10;
+
+my @s = (
+q&&,
+q&say <<'EOT';&,
+q&use v5.10;&,
+q&EOT&,
+q&&,
+q&say 'my @s = (';&,
+q&foreach my $line (@s) {&,
+q&    say 'q'.chr(38).$line.chr(38).','&,
+q&}&,
+q&say ');';&,
+q&&,
+q&foreach my $line (@s) {&,
+q&    say $line&,
+q&}&,
+q&&,
+q&say <<'EOT';&,
+q&__END__&,
+q&&,
+q&./ch-2.pl | diff - ch-2.pl&,
+q&EOT&,
+q&&,
+);
+
+say <<'EOT';
+use v5.10;
+EOT
+
+say 'my @s = (';
+foreach my $line (@s) {
+    say 'q'.chr(38).$line.chr(38).','
+}
+say ');';
+
+foreach my $line (@s) {
+    say $line
+}
+
+say <<'EOT';
+__END__
+
+./ch-2.pl | diff - ch-2.pl
+EOT
+
+__END__
+
+./ch-2.pl | diff - ch-2.pl
+
+```
+
+The solution works by using various quoting operators to embed a copy of the source code within the code itself, which is a common yet powerful way to generate a quine.
+
+## Arne Sommer
+
+[Arne Sommer's solution](https://github.com/manwar/perlweeklychallenge-club/blob/master/challenge-045/arne-sommer/perl/ch-2.pl) uses `$0` to get the script filename, and outputs it line by line:
+
+```perl
+my $file = $0;
+
+if (open(my $fh, $file)) {
+    while (my $row = <$fh>) {
+        print $row;
+    }
+    close $fh;
+}
+```
+
+Arne also submitted [another solution](https://github.com/manwar/perlweeklychallenge-club/blob/master/challenge-045/arne-sommer/perl/ch-2a.pl), even more elegant than the first, which uses [`File::Slurper`](https://metacpan.org/pod/File::Slurper) to read `$0` instead:
+
+```perl
+use File::Slurper 'read_text';
+print read_text($0);
+```
+
+By the way, if you haven't already switched over to `File::Slurper` from `File::Slurp`, I encourage you to do so, as `::Slurper` fixes a lot of the problems in `::Slurp`, especially around the API and handling of encoding.
+
+**Blog** › [Square Dumper with Raku](https://raku-musings.com/square-dumper.html)  
+
+## Burkhard Nickels
+
+[Burkhard Nickels' solution](https://github.com/manwar/perlweeklychallenge-club/blob/master/challenge-045/burkhard-nickels/perl/ch-2.pl) is a source code printer that has gone through some serious research and development! It not only prints its own source code, but it can print the source code of any file. And that's not all: it can also highlight its own syntax with [`Text::VimColor`](https://metacpan.org/pod/Text::VimColor), and even render HTML output if desired. It comes with full internal and [external](https://github.com/manwar/perlweeklychallenge-club/blob/master/challenge-045/burkhard-nickels/perl/ch-2.pod) documentation, too.
+
+I won't quote the full source here, but I will share a few key parts. Here is the source code reader and argument processor:
+
+```perl
+if($ARGV[0] and $ARGV[0] eq "help") {
+    ... # Full help text is here
+}
+elsif($ARGV[0] and $ARGV[0] eq "high") {
+    syntax_high($0,$ARGV[1]);
+}
+elsif($ARGV[0]) {
+    syntax_high(@ARGV);
+}
+else {
+    open(IN,$0) or die "Cant open $0\n";
+    while(<IN>) { print; }
+    close IN;
+}
+```
+
+As you can see, in all cases, the source code is read from `$0`, as we've seen with other solutions.
+
+The syntax highlighting component (in the sub `syntax_high()`) shows just how easy it is to get Vim syntax highlighting in HTML using `Text::VimColor`:
+
+```perl
+    my $syntax = Text::VimColor->new(
+        file => $file,
+        filetype => 'perl',
+        html_full_page => $full,
+    );
+    my $html = $syntax->html;
+```
+
+(Getting ANSI output instead would simply look like `my $ansi = $syntax->ansi`, according to the documentation.)
+
+Burkhard also does a partial HTML parse with `split` to insert his own line numbering, because the `Text::VimColor` line numbering wasn't working for him.
+
+I always like to see solutions like this, that go far above and beyond the challenge, as there is almost guaranteed to be something interesting or unexpected.
+
+### Python
+
+Burkhard submitted a [Python solution](https://github.com/manwar/perlweeklychallenge-club/blob/master/challenge-045/burkhard-nickels/python/ch-2.py) for challenge #2 as well, which uses `__file__` to get the script's filename and then reads from that:
+
+```python
+fh = open(__file__);
+for line in fh:
+    print(line),
+
+fh.close
+```
+
+**Blog** › [Source Dumper](https://github.com/manwar/perlweeklychallenge-club/blob/master/challenge-045/burkhard-nickels/perl/ch-2.pod)
+
+## Colin Crain
+
+[Colin Crain's solution](https://github.com/manwar/perlweeklychallenge-club/blob/master/challenge-045/colin-crain/perl/ch-2.pl) reads the source code from `$0`, and prints it out, along with an observation about sections we'd not normally think of as code, such as the `__DATA__` section:
+
+```perl
+local $/ = undef;
+open (my $fh, "<", $0) or die "can't open this script thats running this code to read: $0 : $!";
+print <$fh>;
+
+__DATA__
+
+even prints the data section, see?
+```
+
+## Cristina Heredia
+
+[Cristina Heredia's solution](https://github.com/manwar/perlweeklychallenge-club/blob/master/challenge-045/cristian-heredia/perl/ch-2.pl) uses a call to `system` to run [cat(1)](https://linux.die.net/man/1/cat) to print the contents:
+
+```perl
+#Name of the script
+my $program = 'ch-2.pl';
+#Execute an unix command
+system("cat $program");
+```
+
+Cristina opted to hard-code the name in `$program`. While this of course means the script can't be renamed or run from a different directory, it does mean that the single-string call to `system` is safe from spaces and metacharacters in the filename, since `$program` is trusted.
+
+The POSIX-only solution is fine by me. My only suggestion would be to switch to the `system PROGRAM LIST` form. The single-argument form (above) won't work (and in fact could be vulnerable to abuse) if the script or given pathname contain spaces or shell metacharacters. This is better:
+
+```perl
+system cat => $0
+```
+
+You could even use `exec` here, as there is no need to ever regain control after `cat` is finished:
+
+```perl
+exec cat => $0
+```
+
+## Dave Cross
+
+[Dave Cross' solution](https://github.com/manwar/perlweeklychallenge-club/blob/master/challenge-045/dave-cross/perl/ch-2.pl) exploits the fact that the `DATA` filehandle is already opened and pointed at the start of the `__DATA__` block in the script (if the script has one), but you are still free to access the contents of the entire script, if you set the filehandle's position with `seek`:
+
+```perl
+seek DATA, 0, 0;
+print while <DATA>;
+__END__
+```
+
+## Dave Jacoby
+
+[Dave Jacoby's solution](https://github.com/manwar/perlweeklychallenge-club/blob/master/challenge-045/dave-jacoby/perl/ch-2.pl) uses [`Cwd`](https://perldoc.perl.org/Cwd.html)'s `abs_path` function to get the absolute path of the script first:
+
+```perl
+use Cwd qw{abs_path};
+
+my $file = abs_path($0);
+if ( -f $file && open my $fh, '<', $file ) {
+    print join '', <$fh>;
+}
+```
+
+From there, Dave does some error checking and uses the three-argument `open`, which is always a good idea. He prints the contents of the file with `join '', <$fh>`, which slurps the entire contents into a list which is then fed to `join`.
+
+**Blog** › [Challenge 45: Cyphers and Quines](https://jacoby.github.io/2020/01/29/challenge-45-cyphers-and-quines.html)
+
+## Duane Powell
+
+[Duane Powell's solution](https://github.com/manwar/perlweeklychallenge-club/blob/master/challenge-045/duane-powell/perl/ch-2.pl) also makes a `system` call to [cat(1)](https://linux.die.net/man/1/cat) to print the contents:
+
+```perl
+system("cat $0");
+```
+
+The same comments I made to Cristina's use of the single-argument `system` apply here; `system cat => $0` is preferable.
+
+## Duncan C. White
+
+[Duncan C. White's solution](https://github.com/manwar/perlweeklychallenge-club/blob/master/challenge-045/duncan-c-white/perl/ch-2.pl) uses `$0` to obtain the script's filename, and loops through the lines:
+
+```perl
+open( my $fh, '<', $0 ) || die "can't read $0\n";
+while( <$fh> )
+{
+    chomp;
+    say;
+}
+```
+
+## E. Choroba
+
+[E. Choroba's solution](https://github.com/manwar/perlweeklychallenge-club/blob/master/challenge-045/e-choroba/perl/ch-2.pl) is another Perl hacker who submitted a full quine:
+
+```perl
+$_=q!print'$_=q*'.$_.'*;';s/\52/\41/g;print!;print'$_=q!'.$_.'!;';s/\52/\41/g;print 
+```
+
+This one again uses the trick of quoting operators to embed a copy of the source, and munging those quoting characters so they are escaped or output as needed. You might think `tr/*/!/` would work, but it would transmute its own arguments in the quoted code, which is why the character codes in `s/\52/\42/g` are necessary.
+
+According to Choroba's blog, this is a quine he came up with, entirely of his own invention, when he started programming Perl, and has tweaked it over the years into the version you see now.
+
+Covering all the bases, he submitted a file reading version as well:
+
+```perl
+seek *DATA, 0, 0;
+print <DATA>
+__DATA__
+```
+
+This one uses the `DATA` filehandle in a similar way as we saw with Dave Cross' solution, above.
+
+**Blog** › [Perl Weekly Challenge 045: Square Secret Code & Source Dumper](http://blogs.perl.org/users/e_choroba/2020/01/perl-weekly-challenge-045-square-secret-code-source-dumper.html)
+
+## Jaldhar H. Vyas
+
+[Jaldhar H. Vyas' solution](https://github.com/manwar/perlweeklychallenge-club/blob/master/challenge-045/jaldhar-h-vyas/perl/ch-2.pl) reads its own source file in slurpy fashion, and uses [`English`](https://perldoc.perl.org/English.html) to aid comprehension:
+
+```perl
+use English qw/ -no_match_vars /;
+
+open my $fh, '<', $PROGRAM_NAME or die "$OS_ERROR\n";
+local $RS = undef;
+print <$fh>;
+```
+
+`English`, a core module, adds plain English aliases for most of Perl's punctuation variables, and manages to use three of them in just two lines of code:
+
+ * › `$PROGRAM_NAME` is `$0`, the script's filename
+ * › `$OS_ERROR` is `$!`, [errno](http://man7.org/linux/man-pages/man3/errno.3.html) error value (or description)
+ * › `$RS` is `$/`, the input record separator, usually newline
+
+**Blog** › [Perl Weekly Challenge - Week 45](https://www.braincells.com/perl/2020/02/perl_weekly_challenge_week_45.html)
+
+## Javier Luque
+
+[Javier Luque's solution](https://github.com/manwar/perlweeklychallenge-club/blob/master/challenge-045/javier-luque/perl/ch-2.pl) reads the file in `$0`, with UTF-8 encoding for good measure:
+
+```perl
+open(my $fh, '<:encoding(UTF-8)', $0) || die "$@";
+while (my $line = <$fh>) {
+    print $line;
+};
+```
+
+**Blog** › [PERL WEEKLY CHALLENGE – 045 – Perl Weekly Challenge](https://perlchallenges.wordpress.com/2020/01/30/perl-weekly-challenge-045/)
+
+## Laurent Rosenfeld
+
+[Laurent Rosenfeld's solution](https://github.com/manwar/perlweeklychallenge-club/blob/master/challenge-045/laurent-rosenfeld/perl/ch-2.pl) is another example of reading one's own source file via `$0`:
+
+```perl
+my $progr = "./$0";
+open my $IN, "<", $progr or die "Unable to open $progr $!";
+print while <$IN>;
+close $IN;
+```
+
+**Blog** › [Perl Weekly Challenge 45: Square Secret Code and Source Dumper](http://blogs.perl.org/users/laurent_r/2020/02/perl-weekly-challenge-45-square-secret-code-and-source-dumper.html)
+
+## Maxim Kolodyazhny
+
+[Maxim Kolodyazhny's solution](https://github.com/manwar/perlweeklychallenge-club/blob/master/challenge-045/maxim-kolodyazhny/perl/ch-2.pl) reads its own source file. You know those two-argument `open` calls I've been talking about? How about a one-argument `open`!
+
+```perl
+use strict;
+use warnings;
+
+open 0 and print <0>;
+```
+
+This might require a bit of explanation if you've never encountered a one-argument `open`. First, it's important to know that there is no special magic with "0" going on, here. Normally `open` requires at least two arguments. The two-argument `open` expects a filehandle, and an expression containing the filename.
+
+When `open` is given just *one* argument, though, Perl takes the filename from the package scalar with the same name as the filehandle. In this case that scalar is `$0`, which is of course the script filename. After that, the `print <0>` part is just a normal read from the filehandle glob named "0" created with `open`.
+
+Don't believe this works as I've described it? Try it with a different name:
+
+```perl
+$PROG = "$0";
+open PROG and print <PROG>
+```
+
+Then make the first line a lexical: `my $PROG = "$0"` and now it doesn't work. In fact, that's part of the reason we avoid bareword scalars these days; they *only* work with package globals, so it's not possible to give them lexical scope.
+
+## Nazareno Delucca
+
+[Nazareno Delucca's solution](https://github.com/manwar/perlweeklychallenge-club/blob/master/challenge-045/ndelucca/perl/ch-2.pl) uses the `__FILE__` function introduced in Perl 5.16 to get the filename:
+
+```perl
+open(my $fh, "<", __FILE__) || die "Couldn't open $0 for reading because: $! ";
+print <$fh>;
+close($fh);
+```
+
+## Rage311
+
+[Rage311's solution](https://github.com/manwar/perlweeklychallenge-club/blob/master/challenge-045/rage311/perl/ch-2.pl) reads the file in `$0`, complete with error handling and the three-argument `open`:
+
+```perl
+die "Unable to open file: $!" unless
+  open my $fh, '<', $0;
+print while <$fh>;
+```
+
+## Roger Bell West
+
+[Roger Bell West's solution](https://github.com/manwar/perlweeklychallenge-club/blob/master/challenge-045/roger-bell-west/perl/ch-2.pl) eschews all modern Perl contrivances for the following concise solution:
+
+```perl
+open F,$0;
+print <F>;
+```
+
+## Ruben Westerberg
+
+[Ruben Westerberg's solution](https://github.com/manwar/perlweeklychallenge-club/blob/master/challenge-045/ruben-westerberg/perl/ch-2.pl) shows that those modern features can look pretty, too:
+
+```perl
+open my $f,"<",$0;
+print $_ for ( <$f> );
+```
+
+## Ryan Thompson
+
+I submitted three solutions this week, to showcase three different and progressively more difficult ways this challenge could be solved.
+
+First up—and I can't believe [I actually committed this](https://github.com/manwar/perlweeklychallenge-club/blob/master/challenge-045/ryan-thompson/perl/ch-2a.pl)—an **empty file** works as a valid script. This arguably meets the letter of the challenge, but probably not the spirit. All serious definitions of quines regard this as cheating, too.
+
+So the next best thing is [my own version](https://github.com/manwar/perlweeklychallenge-club/blob/master/challenge-045/ryan-thompson/perl/ch-2.pl) of the source file reader:
+
+```perl
+open my $fh, '<', __FILE__;
+print do { undef $/; <$fh> };
+```
+
+I opted to slurp `<$fh>` into a string, although I really didn't need to.
+
+But my third solution, finally, is a real quine. The source code is not really human readable, but you can [see it here](https://github.com/manwar/perlweeklychallenge-club/blob/master/challenge-045/ryan-thompson/perl/ch-2b.pl). It was, as it turns out, human *writeable,* although I wouldn't recommend replicating my methods.
+
+Its output, when fed to a terminal, is displayed just a bit differently:
+
+![I <3 Perl](http://www.ry.ca/wp-content/uploads/2020/02/image.png)
+
+When fed to `diff`, `diff` will happily compare the output—including all of the ANSI escape codes—and report no differences.
+
+For a more human-readable introduction to what I did, I started with the following quine:
+
+```perl
+$_=q<"ANSI ART HERE";print"\$_=q<$_>;eval\n">;eval
+```
+
+As discussed in my blog, I do not claim to have invented this quine, as it's pretty difficult to come up with a completely novel quine after all these years. Similar versions are rather ubiquitious in Perl quine discussions, due to how powerful the quoting operators are in Perl.
+
+I then got to work with my amazing ANSI art skills, at the position shown. Maybe I could get rich selling signed prints.
+
+**Blog** › [Quine](http://www.ry.ca/2020/02/quine/)
+
+ ## Saif Ahmed
+
+[Saif Ahmed's solution](https://github.com/manwar/perlweeklychallenge-club/blob/master/challenge-045/saiftynet/perl/ch-2.pl) is another file read solution, with UTF-8 encoding:
+
+```perl
+open (my $fh, '<:encoding(UTF-8)', $0 ) ;
+print while(<$fh>);
+```
+
+## Ulrich Rieke
+
+[Ulrich Rieke's solution](https://github.com/manwar/perlweeklychallenge-club/blob/master/challenge-045/ulrich-rieke/perl/ch-2.pl) reads the file via a filehandle glob:
+
+```perl
+open (FH , "< $0" ) or die "Can't open file $0!\n" ;
+while ( <FH> ) {
+  print ;
+}
+close (FH) ;
+```
+
+## Wanderdoc
+
+[Wanderdoc's solution](https://github.com/manwar/perlweeklychallenge-club/blob/master/challenge-045/wanderdoc/perl/ch-2.pl) reads `$0`:
+
+```perl
+open my $in, "<", $0 or die "$!";
+for ( <$in> ) {print $_;}
+```
+
+***
+
+And that's it! Although a lot of these solutions were quite similar, it's amazing how much variation in style one can achieve in just two or three lines.
+
+
+***
+***
+
+## SEE ALSO {#blogs}
+
+### Blogs this week:
+
+Great to see more people blogging again this week! I always enjoy reading them.
+
+**Adam Russell** › [Perl Fun](https://adamcrussell.livejournal.com/15213.html)
+
+**Arne Sommer** › [Square Dumper with Raku](https://raku-musings.com/square-dumper.html)
+
+**Burkhard Nickels** › [Square Secret Code](https://github.com/manwar/perlweeklychallenge-club/blob/master/challenge-045/burkhard-nickels/perl/ch-1.pod) | [Source Dumper](https://github.com/manwar/perlweeklychallenge-club/blob/master/challenge-045/burkhard-nickels/perl/ch-2.pod)
+
+**Dave Jacoby** › [Challenge 45: Cyphers and Quines](https://jacoby.github.io/2020/01/29/challenge-45-cyphers-and-quines.html)
+
+**E. Choroba** › [Square Secret Code & Source Dumper](http://blogs.perl.org/users/e_choroba/2020/01/perl-weekly-challenge-045-square-secret-code-source-dumper.html)
+
+**Jaldhar H. Vyas** › [Perl Weekly Challenge Week 45](https://www.braincells.com/perl/2020/02/perl_weekly_challenge_week_45.html)
+
+**Javier Luque** › [045 – Perl Weekly Challenge](https://perlchallenges.wordpress.com/2020/01/30/perl-weekly-challenge-045/)
+
+**Laurent Rosenfeld** › [Square Secret Code and Source Dumper](http://blogs.perl.org/users/laurent_r/2020/02/perl-weekly-challenge-45-square-secret-code-and-source-dumper.html)
+
+**Luca Ferrari** › [Encoded messages and self-source-code-printing](https://fluca1978.github.io/2020/01/29/PerlWeeklyChallenge45.html)
+
+**Ryan Thompson** › [Square Secret Code](http://www.ry.ca/2020/01/square-secret-code/) | [Quine](http://www.ry.ca/2020/02/quine/)


### PR DESCRIPTION
Here are the Perl and Raku reviews for the past week. I've made a change to `config.toml` to allow HTML in markdown, which was necessary for proper scaling of the vector images I used for the social media links.